### PR TITLE
feat: hardened streaming chunked upload (rebased from #5)

### DIFF
--- a/file.py
+++ b/file.py
@@ -6,6 +6,7 @@ from db import FileDb
 import hashlib
 from file_types import detect_file_type
 import threading
+import random
 
 _upload_lock = threading.Lock()
 
@@ -115,3 +116,202 @@ def force_delete_file(port_api : int, hashes : str, file_cursor : FileDb):
     target_path = file_path(port_api, hashes)
     if os.path.isfile(target_path):
         os.remove(target_path)
+
+
+# Experimental: streaming chunked upload for large files (resume + integrity check).
+# Hardened vs the original #5 draft: track received chunks, incremental hash,
+# per-file size ceiling, uid-scoped temps, concurrent-upload limit.
+def chunked_upload_file(port_api : int, uid : int, file_name : str, chunk_index : int, chunk_total : int, chunk_data_b64 : str, file_id : str = None, file_cursor : FileDb = None, expected_hash : str = None):
+    """
+    Stream a file in chunks to avoid loading the whole payload into RAM.
+
+    :return: dict with success/error, plus file_id (intermediate) or file_hash (final)
+    """
+    MAX_CHUNK_SIZE = 10 * 1024 * 1024
+    MAX_TOTAL_SIZE = 200 * 1024 * 1024
+
+    if not isinstance(uid, int):
+        return {"success": False, "error": "Invalid uid"}
+    if not isinstance(chunk_index, int) or not isinstance(chunk_total, int) or chunk_index < 0 or chunk_total < 1 or chunk_index >= chunk_total:
+        return {"success": False, "error": "Invalid chunk parameters"}
+
+    if chunk_total * MAX_CHUNK_SIZE > MAX_TOTAL_SIZE:
+        return {"success": False, "error": "File too large"}
+
+    try:
+        decoded_chunk = base64.b64decode(chunk_data_b64)
+    except Exception:
+        return {"success": False, "error": "Decode failed"}
+
+    if len(decoded_chunk) > MAX_CHUNK_SIZE:
+        return {"success": False, "error": "Chunk too large"}
+
+    chunk_dir = "res/{}/file/".format(port_api)
+
+    if chunk_index == 0:
+        if os.path.isdir(chunk_dir):
+            for fname in os.listdir(chunk_dir):
+                if fname.startswith(".tmp_{}_".format(uid)):
+                    try:
+                        fpath = os.path.join(chunk_dir, fname)
+                        if time.time() - os.path.getmtime(fpath) > 3600:
+                            os.remove(fpath)
+                    except OSError:
+                        pass
+            existing_ids = set()
+            for fname in os.listdir(chunk_dir):
+                if fname.startswith(".tmp_{}_".format(uid)):
+                    parts = fname.split("_")
+                    if len(parts) >= 4:
+                        existing_ids.add(parts[2])
+            if len(existing_ids) >= 5:
+                return {"success": False, "error": "Too many concurrent uploads"}
+
+        file_id = sha256(str(time.time()) + str(uid) + file_name)
+        prefix = ".tmp_{}_{}_".format(uid, file_id)
+        if os.path.isdir(chunk_dir):
+            for fname in os.listdir(chunk_dir):
+                if fname.startswith(prefix):
+                    try:
+                        os.remove(os.path.join(chunk_dir, fname))
+                    except OSError:
+                        pass
+        try:
+            if not os.path.exists(chunk_dir):
+                os.makedirs(chunk_dir)
+        except Exception:
+            return {"success": False, "error": "Directory creation failed"}
+        total_path_tmp = os.path.join(chunk_dir, ".tmp_{}_{}_total".format(uid, file_id))
+        try:
+            with open(total_path_tmp, "w") as tf:
+                tf.write(str(chunk_total))
+        except Exception:
+            return {"success": False, "error": "Failed to record chunk info"}
+    else:
+        if not file_id:
+            return {"success": False, "error": "Missing file_id"}
+        chunk0 = os.path.join(chunk_dir, ".tmp_{}_{}_0".format(uid, file_id))
+        if not os.path.exists(chunk0):
+            return {"success": False, "error": "Invalid file_id"}
+        total_path_tmp = os.path.join(chunk_dir, ".tmp_{}_{}_total".format(uid, file_id))
+        try:
+            with open(total_path_tmp, "r") as tf:
+                recorded_total = int(tf.read().strip())
+        except Exception:
+            return {"success": False, "error": "Failed to read chunk info"}
+        if recorded_total != chunk_total:
+            return {"success": False, "error": "chunk_total mismatch"}
+
+    chunk_path = os.path.join(chunk_dir, ".tmp_{}_{}_{}".format(uid, file_id, chunk_index))
+    try:
+        with open(chunk_path, "wb") as f:
+            f.write(decoded_chunk)
+    except Exception:
+        return {"success": False, "error": "Write failed"}
+
+    if chunk_index == chunk_total - 1:
+        combined = os.path.join(chunk_dir, ".tmp_{}_final_{}".format(file_id, random.getrandbits(64)))
+        total_path_tmp = os.path.join(chunk_dir, ".tmp_{}_{}_total".format(uid, file_id))
+
+        def cleanup_chunks():
+            for i in range(chunk_total):
+                try:
+                    os.remove(os.path.join(chunk_dir, ".tmp_{}_{}_{}".format(uid, file_id, i)))
+                except OSError:
+                    pass
+            try:
+                os.remove(total_path_tmp)
+            except OSError:
+                pass
+
+        try:
+            for i in range(chunk_total):
+                cp = os.path.join(chunk_dir, ".tmp_{}_{}_{}".format(uid, file_id, i))
+                if not os.path.exists(cp):
+                    return {"success": False, "error": "Missing chunk {}".format(i)}
+
+            sha256_hash = hashlib.sha256()
+            total_size = 0
+            with open(combined, "wb") as out:
+                for i in range(chunk_total):
+                    cp = os.path.join(chunk_dir, ".tmp_{}_{}_{}".format(uid, file_id, i))
+                    with open(cp, "rb") as f:
+                        while True:
+                            piece = f.read(1024 * 1024)
+                            if not piece:
+                                break
+                            out.write(piece)
+                            sha256_hash.update(piece)
+                            total_size += len(piece)
+
+            file_hash = sha256_hash.hexdigest()
+
+            if expected_hash and file_hash != expected_hash:
+                try:
+                    os.remove(combined)
+                except OSError:
+                    pass
+                cleanup_chunks()
+                return {"success": False, "error": "Hash verification failed"}
+
+            final_path = file_path(port_api, file_hash)
+            try:
+                with open(combined, "rb") as probe:
+                    head = probe.read(4096)
+                file_type = detect_file_type(head, file_name)
+            except Exception:
+                file_type = detect_file_type(b"", file_name)
+            extension = os.path.splitext(file_name)[1].lower()
+
+            with _upload_lock:
+                wrote_blob = False
+                try:
+                    registered = False
+                    if file_cursor is not None:
+                        registered = file_cursor.file_exists(file_hash)
+                    if not registered or not os.path.isfile(final_path):
+                        os.rename(combined, final_path)
+                        wrote_blob = True
+                    else:
+                        try:
+                            os.remove(combined)
+                        except OSError:
+                            pass
+
+                    if file_cursor is not None:
+                        file_cursor.register_upload(
+                            uid, file_hash, file_name, time.time(), total_size,
+                            mime_type=file_type, extension=extension,
+                        )
+                except Exception:
+                    if wrote_blob and os.path.isfile(final_path):
+                        try:
+                            still = file_cursor.file_exists(file_hash) if file_cursor else True
+                        except Exception:
+                            still = True
+                        if not still:
+                            try:
+                                os.remove(final_path)
+                            except OSError:
+                                pass
+                    elif os.path.exists(combined):
+                        try:
+                            os.remove(combined)
+                        except OSError:
+                            pass
+                    cleanup_chunks()
+                    return {"success": False, "error": "Finalization failed"}
+
+            cleanup_chunks()
+            return {"success": True, "file_hash": file_hash, "verified": expected_hash is not None}
+        except Exception:
+            if os.path.exists(combined):
+                try:
+                    os.remove(combined)
+                except OSError:
+                    pass
+            cleanup_chunks()
+            return {"success": False, "error": "Finalization failed"}
+
+    return {"success": True, "file_id": file_id}
+

--- a/web.py
+++ b/web.py
@@ -2132,6 +2132,96 @@ def main(port_api : int, port_tcp : int, pub_pem, pri, ImgCaptcha, user_cursor, 
             "file" : file_metadata(hashes, uid),
         }, ensure_ascii=False)
 
+    # Experimental: streaming chunked upload (rebased + hardened from Leitarkkk #5).
+    @api('/file/chunked_upload', methods=['POST'])
+    def chunked_upload(req):
+        """
+        Stream large files in chunks.
+
+        Request params:
+        - uid, password, filename
+        - chunk_index (0-based), chunk_total
+        - chunk_data (base64)
+        - file_id (required after first chunk)
+        - expected_hash (optional SHA256 of full file)
+        """
+        try:
+            uid = req["uid"]
+            password = req["password"]
+            filename = req["filename"]
+            chunk_index = req["chunk_index"]
+            chunk_total = req["chunk_total"]
+            chunk_data = req["chunk_data"]
+            file_id = req.get("file_id", None)
+            expected_hash = req.get("expected_hash", None)
+
+            if not isinstance(uid, int):
+                return json.dumps({"success": False, "error": "Invalid uid"}, ensure_ascii=False)
+            if not user_cursor.verify_user(uid, password):
+                return json.dumps({"success": False, "error": "Password incorrect"}, ensure_ascii=False)
+            user_row = get_user_row(uid)
+            if user_row is None:
+                return json.dumps({"success": False, "error": "User not found"}, ensure_ascii=False)
+            if user_row[4] == 'banned':
+                return json.dumps({"success": False, "error": "User banned"}, ensure_ascii=False)
+
+            cfg = read_config()
+            normalized_name = normalize_upload_filename(filename)
+            if normalized_name is None:
+                return json.dumps({"success": False, "error": "Invalid filename"}, ensure_ascii=False)
+            allowed_extensions = read_allowed_file_extensions(cfg)
+            if allowed_extensions:
+                _, ext = os.path.splitext(normalized_name.lower())
+                if not ext or ext not in allowed_extensions:
+                    return json.dumps({"success": False, "error": "Extension not allowed"}, ensure_ascii=False)
+
+            result = file.chunked_upload_file(
+                port_api,
+                uid,
+                normalized_name,
+                chunk_index,
+                chunk_total,
+                chunk_data,
+                file_id,
+                file_cursor,
+                expected_hash,
+            )
+
+            # Enforce user storage quota on successful finalization.
+            if result.get("success") and result.get("file_hash"):
+                quota = cfg.get("user_storage_quota", -1)
+                if quota != -1:
+                    hashes = result["file_hash"]
+                    meta = file_metadata(hashes, uid) or {}
+                    new_size = int(meta.get("size") or meta.get("file_size") or 0)
+                    current_usage = file_cursor.get_user_storage_used(uid)
+                    # register_upload already counted this file; approximate by
+                    # checking whether usage already includes it via has_active.
+                    if new_size and current_usage > quota:
+                        file.dereference_file(
+                            port_api, uid, hashes, file_cursor,
+                            cfg.get("file_last_time", 72),
+                        )
+                        return json.dumps(
+                            {"success": False, "error": "Storage quota exceeded"},
+                            ensure_ascii=False,
+                        )
+                return json.dumps({
+                    "success": True,
+                    "file_hash": result["file_hash"],
+                    "verified": result.get("verified", False),
+                    "hash": result["file_hash"],
+                    "download_url": "/file/get_file/{}".format(result["file_hash"]),
+                    "info_url": "/file/get_file_info/{}".format(result["file_hash"]),
+                    "file": file_metadata(result["file_hash"], uid),
+                }, ensure_ascii=False)
+
+            return json.dumps(result, ensure_ascii=False)
+        except KeyError as e:
+            return json.dumps({"success": False, "error": "Missing parameter"}, ensure_ascii=False)
+        except Exception:
+            return json.dumps({"success": False, "error": "Server error"}, ensure_ascii=False)
+
     @api('/file/dereference_file', methods=['POST'])
     def dereference_file(req):
         uid = req["uid"]


### PR DESCRIPTION
## Summary

Following up on Mark's review of the streaming upload path in [Leitarkkk/TFV5_server#5](https://github.com/2044-space-elevator/TFV5_server/pull/5) (mirrored at [marginsystems/TFV5_server#1](https://github.com/marginsystems/TFV5_server/pull/1)).

Per John's request: **rebased onto current `main`** and opened directly against this repo.

This ports the experimental `/file/chunked_upload` feature onto today's upload stack (`register_upload`, filename validation, storage quota helpers) and includes the hardening from our Vortex/Tempest review:

- Reject incomplete uploads (track received chunk files; require `0..chunk_total-1` before finalize)
- Incremental SHA-256 during merge (no full-file `f.read()` into RAM)
- Per-file total size ceiling (200MB) + existing 10MB per-chunk limit
- UID-scoped temp files, stale cleanup, concurrent-upload limit
- Content-addressed final blob + `register_upload` integration

## Test plan

- [ ] Upload a small multi-chunk file end-to-end via `/file/chunked_upload`
- [ ] Skip a middle chunk and confirm finalize fails with missing chunk
- [ ] Confirm hash mismatch rejects and cleans temp chunks
- [ ] Confirm banned user / bad password / bad filename are rejected
- [ ] Confirm storage quota still enforced on finalization when configured

Happy for you to take or ignore any of this — no hard feelings either way.

Made with [Cursor](https://cursor.com)