### PR TITLE
[perf] 批量通知写入推送、配置缓存、DB 连接优化

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -42,6 +42,16 @@ def _metadata_with_name(metadata, file_name):
     return result
 
 
+def alert_from_preference(pref, uid, mentioned_uids) -> bool:
+    """根据房间偏好判断是否需要提醒。pref 为 get_room_preference 的 dict，缺省按 0 级处理。"""
+    level = int((pref or {}).get("notify_level", 0))
+    if level == 2:
+        return False
+    if level == 1:
+        return uid in mentioned_uids
+    return True
+
+
 def can_access_room(user_cursor, group_cursor, uid: int, room_id: str) -> bool:
     if not isinstance(room_id, str) or len(room_id) < 2:
         return False
@@ -215,6 +225,34 @@ class InstantConnect():
                 self.loop
             )
         return record
+
+    def notify_users(self, uid_notifications) -> list:
+        """批量写入通知并推送给各自已连接的客户端，单事务提交。
+
+        :param uid_notifications: [(uid, notification), ...]
+        :return: [{time_stamp, info}, ...]
+        """
+        if not uid_notifications:
+            return []
+        prepared = [(int(uid), dict(notification)) for uid, notification in uid_notifications]
+        timestamps = self.notification_cursor.add_events(prepared)
+        with self._clients_lock:
+            client_map = {
+                uid: list(self.connected_clients.get(uid, []))
+                for uid, _ in prepared
+            }
+        records = []
+        for (uid, notification), time_stamp in zip(prepared, timestamps):
+            record = {"time_stamp" : time_stamp, "info" : notification}
+            records.append(record)
+            if self.loop is None:
+                continue
+            for websocket in client_map.get(uid, []):
+                asyncio.run_coroutine_threadsafe(
+                    self._queue_message(websocket, {"type" : "NOTIFICATION.NEW", "notification" : record}),
+                    self.loop
+                )
+        return records
 
     def disconnect_user(self, uid : int):
         if self.loop is None:
@@ -429,20 +467,20 @@ class InstantConnect():
                         notif_dict["quote_preview"] = (
                             self.messages_cursor.get_quote_preview(quote, msg_record) if quote >= 0 else None
                         )
+                        room_id = "G{}".format(gid)
+                        pref_map = self.messages_cursor.get_room_preference_map(members, room_id) if members else {}
+                        sender_uid = self.clients_belonged[websocket]
+                        pending = []
                         for user in members:
                             user_notif = dict(notif_dict)
                             user_notif["mentioned_uids"] = mentioned_uids
                             user_notif["mentions_me"] = user in mentioned_uids
                             user_notif["should_alert"] = (
-                                user != self.clients_belonged[websocket]
-                                and should_alert(
-                                    self.messages_cursor,
-                                    user,
-                                    "G{}".format(gid),
-                                    mentioned_uids,
-                                )
+                                user != sender_uid
+                                and alert_from_preference(pref_map.get(user), user, mentioned_uids)
                             )
-                            await self._notify_user_async(user, user_notif)
+                            pending.append((user, user_notif))
+                        await asyncio.to_thread(self.notify_users, pending)
 
                     else:
                         self._queue_ack(websocket, client_mid, status="failed", error="invalid_target")
@@ -617,17 +655,20 @@ class InstantConnect():
                                 ),
                                 metadata["file_name"],
                             )
+                        room_id = "G{}".format(gid)
+                        pref_map = self.messages_cursor.get_room_preference_map(members, room_id) if members else {}
+                        sender_uid = self.clients_belonged[websocket]
+                        pending = []
                         for user in members:
                             user_notif = dict(notif_dict)
                             user_notif["mentioned_uids"] = []
                             user_notif["mentions_me"] = False
                             user_notif["should_alert"] = (
-                                user != self.clients_belonged[websocket]
-                                and should_alert(
-                                    self.messages_cursor, user, "G{}".format(gid), []
-                                )
+                                user != sender_uid
+                                and alert_from_preference(pref_map.get(user), user, [])
                             )
-                            await self._notify_user_async(user, user_notif)
+                            pending.append((user, user_notif))
+                        await asyncio.to_thread(self.notify_users, pending)
 
                     else:
                         self._queue_ack(websocket, client_mid, status="failed", error="invalid_target")

--- a/channel.py
+++ b/channel.py
@@ -508,7 +508,10 @@ class InstantConnect():
                                 and alert_from_preference(pref_map.get(user), user, mentioned_uids)
                             )
                             pending.append((user, user_notif))
-                        await asyncio.to_thread(self.notify_users, pending)
+                        try:
+                            await asyncio.to_thread(self.notify_users, pending)
+                        except Exception as e:
+                            print("[WARN] 批量通知失败(群{}): {}".format(gid, e))
 
                     else:
                         self._queue_ack(websocket, client_mid, status="failed", error="invalid_target")
@@ -700,7 +703,10 @@ class InstantConnect():
                                 and alert_from_preference(pref_map.get(user), user, [])
                             )
                             pending.append((user, user_notif))
-                        await asyncio.to_thread(self.notify_users, pending)
+                        try:
+                            await asyncio.to_thread(self.notify_users, pending)
+                        except Exception as e:
+                            print("[WARN] 批量通知失败(群{}): {}".format(gid, e))
 
                     else:
                         self._queue_ack(websocket, client_mid, status="failed", error="invalid_target")

--- a/db/dialect.py
+++ b/db/dialect.py
@@ -184,6 +184,7 @@ class SQLiteDialect(SQLDialect):
         import sqlite3
         conn = sqlite3.connect(dsn, timeout=10)
         conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA synchronous=NORMAL")
         conn.execute("PRAGMA busy_timeout=5000")
         return conn
 

--- a/db/group.py
+++ b/db/group.py
@@ -64,12 +64,12 @@ class GroupDb(Db):
                 essence_query = self.cursor.fetchone()
                 if not essence_query:
                     return False
-                essence_query = eval(essence_query[9])
+                essence_query = json.loads(essence_query[9])
                 if mid in essence_query:
                     return False
                 essence_query.append(mid)
                 essence_query.sort(reverse=True)
-                self.cursor.execute("UPDATE groups SET essence = ? WHERE gid = ?", (str(essence_query), gid));
+                self.cursor.execute("UPDATE groups SET essence = ? WHERE gid = ?", (json.dumps(essence_query), gid));
                 self.conn.commit()
                 return True;
             return self._execute_with_retry(_add_essence)
@@ -81,11 +81,11 @@ class GroupDb(Db):
                 essence_query = self.cursor.fetchone()
                 if not essence_query:
                     return False
-                essence_query = eval(essence_query[9])
+                essence_query = json.loads(essence_query[9])
                 if not mid in essence_query:
                     return False
                 essence_query.remove(mid)
-                self.cursor.execute("UPDATE groups SET essence = ? WHERE gid = ?", (str(essence_query), gid))
+                self.cursor.execute("UPDATE groups SET essence = ? WHERE gid = ?", (json.dumps(essence_query), gid))
                 self.conn.commit()
                 return True
             return self._execute_with_retry(_remove_essence)
@@ -94,7 +94,7 @@ class GroupDb(Db):
         essence_query = self.query("SELECT * FROM groups WHERE gid = ?", (gid, ))
         if not essence_query:
             return []
-        essence_query = eval(essence_query[0][9])
+        essence_query = json.loads(essence_query[0][9])
         return essence_query
 
     def _migrate(self):

--- a/db/group.py
+++ b/db/group.py
@@ -58,17 +58,13 @@ class GroupDb(Db):
         self._migrate()
 
     def _parse_essence(self, raw) -> list:
-        """安全解析 essence 列，兼容 None / JSON / Python list 字面量。"""
         if not raw:
             return []
         try:
-            return json.loads(raw)
+            result = json.loads(raw)
+            return result if isinstance(result, list) else []
         except (ValueError, TypeError):
-            try:
-                result = eval(raw)
-                return result if isinstance(result, list) else []
-            except Exception:
-                return []
+            return []
 
     def add_essence(self, gid, mid):
         with self.lock:

--- a/db/messages.py
+++ b/db/messages.py
@@ -455,6 +455,22 @@ class MessagesDb(Db):
             for row in rows
         }
 
+    def get_room_preference_map(self, uids, room_id: str) -> dict:
+        """批量获取多个用户对同一房间的通知偏好，单次查询。"""
+        uids = [int(uid) for uid in set(uids)]
+        if not uids:
+            return {}
+        placeholders = ",".join("?" * len(uids))
+        rows = self.query(
+            "SELECT uid, is_pinned, notify_level FROM room_preferences "
+            "WHERE uid IN ({}) AND room_id = ?".format(placeholders),
+            tuple(uids) + (room_id,),
+        )
+        return {
+            row[0]: {"is_pinned": bool(row[1]), "notify_level": int(row[2])}
+            for row in rows
+        }
+
     def get_room_preference(self, uid: int, room_id: str) -> dict:
         rows = self.query(
             "SELECT is_pinned, notify_level FROM room_preferences WHERE uid = ? AND room_id = ?",

--- a/db/notifications.py
+++ b/db/notifications.py
@@ -96,6 +96,30 @@ CREATE TABLE IF NOT EXISTS notifications (
         )
         return ts
 
+    def add_events(self, uid_and_events) -> list:
+        """批量插入多条通知，单事务提交，返回与输入顺序一致的时间戳列表。
+
+        :param uid_and_events: [(uid, event), ...]
+        """
+        if not uid_and_events:
+            return []
+        now = time.time()
+        values = []
+        timestamps = []
+        for index, (uid, event) in enumerate(uid_and_events):
+            ts = now + index * 1e-6
+            values.append((int(uid), ts, self._serialize_event(event)))
+            timestamps.append(ts)
+        with self.lock:
+            def operation():
+                self.cursor.executemany(
+                    "INSERT INTO notifications (uid, time_stamp, info) VALUES (?, ?, ?)",
+                    values,
+                )
+                self.conn.commit()
+            self._execute_with_retry(operation)
+        return timestamps
+
     def redact_recalled_message(self, mid : int):
         """删除消息内容，保留引用预览"""
         with self.lock:

--- a/db/tool.py
+++ b/db/tool.py
@@ -2,29 +2,53 @@ import sqlite3
 import threading
 import time
 
+
 class Db:
     def __init__(self, path: str, PORT_API: int, PORT_TCP: int, WAL_mode=True, max_retries=3):
         self.path = path
         self.api_pt = PORT_API
         self.tcp_pt = PORT_TCP
         self.WAL_mode = WAL_mode
-        self.max_retries = max_retries          
+        self.max_retries = max_retries
+        # 写锁：串行化所有写操作。读操作在 WAL 模式下并发，不加这把锁。
         self.lock = threading.Lock()
-        self._connect()                         
+        # 每线程一个独立连接，避免单连接 + 单锁把读也串行化。
+        self._local = threading.local()
+        # 初始化主线程连接（触发 WAL 等 PRAGMA）。
+        _ = self.conn
 
     def _connect(self):
-        self.conn = sqlite3.connect(self.path, check_same_thread=False)
-        self.cursor = self.conn.cursor()
+        conn = sqlite3.connect(self.path, check_same_thread=False)
         if self.WAL_mode:
-            self.cursor.execute('PRAGMA journal_mode=WAL')
+            conn.execute("PRAGMA journal_mode=WAL")
+        # WAL + synchronous=NORMAL：写性能大幅提升，崩溃时最多丢最后一次事务。
+        conn.execute("PRAGMA synchronous=NORMAL")
+        # 写冲突时等待而不是立刻报错。
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    @property
+    def conn(self):
+        conn = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = self._connect()
+            self._local.conn = conn
+            self._local.cursor = conn.cursor()
+        return conn
+
+    @property
+    def cursor(self):
+        _ = self.conn
+        return self._local.cursor
 
     def _reconnect(self):
         try:
-            if self.conn:
-                self.conn.close()
+            if getattr(self._local, "conn", None) is not None:
+                self._local.conn.close()
         except Exception:
             pass
-        self._connect()
+        self._local.conn = self._connect()
+        self._local.cursor = self._local.conn.cursor()
 
     def _execute_with_retry(self, db_operation, *args, **kwargs):
         for attempt in range(self.max_retries):
@@ -32,9 +56,9 @@ class Db:
                 return db_operation(*args, **kwargs)
             except (sqlite3.OperationalError, sqlite3.ProgrammingError) as e:
                 if attempt == self.max_retries - 1:
-                    raise  
+                    raise
                 self._reconnect()
-                time.sleep(0.1)   
+                time.sleep(0.1)
             except Exception:
                 raise
 
@@ -46,14 +70,14 @@ class Db:
             self._execute_with_retry(operation)
 
     def query(self, command: str, parameters: tuple = None):
-        with self.lock:
-            def operation():
-                if parameters:
-                    self.cursor.execute(command, parameters)
-                else:
-                    self.cursor.execute(command)
-                return self.cursor.fetchall()
-            return self._execute_with_retry(operation)
+        # 读操作不加锁：每个线程用自己的连接，WAL 下可并行读取。
+        def operation():
+            if parameters:
+                self.cursor.execute(command, parameters)
+            else:
+                self.cursor.execute(command)
+            return self.cursor.fetchall()
+        return self._execute_with_retry(operation)
 
     def execute(self, command: str, parameters: tuple = None):
         with self.lock:
@@ -71,5 +95,8 @@ class Db:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.conn:
-            self.conn.close()
+        try:
+            if getattr(self._local, "conn", None) is not None:
+                self._local.conn.close()
+        except Exception:
+            pass

--- a/db/tool.py
+++ b/db/tool.py
@@ -1,4 +1,3 @@
-import sqlite3
 import threading
 import time
 
@@ -6,58 +5,22 @@ from db.dialect import CursorProxy, SQLiteDialect
 
 
 class Db:
-    def __init__(self, path_or_dsn, PORT_API: int, PORT_TCP: int,
+    def __init__(self, path_or_dsn, PORT_API, PORT_TCP,
                  WAL_mode=True, max_retries=3, dialect=None):
         self.path = path_or_dsn
         self.api_pt = PORT_API
         self.tcp_pt = PORT_TCP
         self.WAL_mode = WAL_mode
         self.max_retries = max_retries
+        if dialect is None:
+            dialect = SQLiteDialect()
+        self.dialect = dialect
         # 写锁：串行化所有写操作。读操作在 WAL 模式下并发，不加这把锁。
         self.lock = threading.Lock()
         # 每线程一个独立连接，避免单连接 + 单锁把读也串行化。
         self._local = threading.local()
         # 初始化主线程连接（触发 WAL 等 PRAGMA）。
         _ = self.conn
-
-    def _connect(self):
-        conn = sqlite3.connect(self.path, check_same_thread=False)
-        if self.WAL_mode:
-            conn.execute("PRAGMA journal_mode=WAL")
-        # WAL + synchronous=NORMAL：写性能大幅提升，崩溃时最多丢最后一次事务。
-        conn.execute("PRAGMA synchronous=NORMAL")
-        # 写冲突时等待而不是立刻报错。
-        conn.execute("PRAGMA busy_timeout=5000")
-        return conn
-
-    @property
-    def conn(self):
-        conn = getattr(self._local, "conn", None)
-        if conn is None:
-            conn = self._connect()
-            self._local.conn = conn
-            self._local.cursor = conn.cursor()
-        return conn
-
-    @property
-    def cursor(self):
-        _ = self.conn
-        return self._local.cursor
-
-    def _reconnect(self):
-        try:
-            if getattr(self._local, "conn", None) is not None:
-                self._local.conn.close()
-        except Exception:
-            pass
-        self._local.conn = self._connect()
-        self._local.cursor = self._local.conn.cursor()
-        if dialect is None:
-            dialect = SQLiteDialect()
-        self.dialect = dialect
-        self.lock = threading.Lock()
-        self._local = threading.local()
-        self._init_thread()
 
     def _init_thread(self):
         conn = self.dialect.connect(self.path)
@@ -92,7 +55,7 @@ class Db:
 
     def _execute_with_retry(self, db_operation, *args, **kwargs):
         error_types = self.dialect.retryable_error_types or (
-            sqlite3.OperationalError,
+            self.dialect.DatabaseError,
         )
         for attempt in range(self.max_retries):
             try:

--- a/web.py
+++ b/web.py
@@ -60,9 +60,22 @@ def main(port_api : int, port_tcp : int, pub_pem, pri, ImgCaptcha, user_cursor, 
         'announcement': threading.Lock(),
     }
 
+    _config_cache = {"data": None, "ts": 0.0}
+    _CONFIG_TTL = 2.0
+
+    def invalidate_config_cache():
+        _config_cache["data"] = None
+
     def read_config():
         with locks['config']:
-            return read_json("res/{}/config.json".format(port_api))
+            cached = _config_cache
+            now = time.time()
+            if cached["data"] is not None and now - cached["ts"] < _CONFIG_TTL:
+                return cached["data"]
+            data = read_json("res/{}/config.json".format(port_api))
+            cached["data"] = data
+            cached["ts"] = now
+            return data
 
     group_cursor._config_reader = read_config
 
@@ -141,6 +154,7 @@ def main(port_api : int, port_tcp : int, pub_pem, pri, ImgCaptcha, user_cursor, 
                 mutator(cfg)
                 state["cfg"] = dict(cfg)
             update_json("res/{}/config.json".format(port_api), apply)
+            invalidate_config_cache()
             return state["cfg"]
 
     def serialize_server_settings(cfg, include_manage=False):
@@ -626,6 +640,7 @@ def main(port_api : int, port_tcp : int, pub_pem, pri, ImgCaptcha, user_cursor, 
                     cfg["email_activate"] = req["verify_email"]
                     cfg["email_password"] = req["email_password"]
             update_json("res/{}/config.json".format(port_api), change)
+            invalidate_config_cache()
         return bool_res()[True]
         
     @app.route("/auth/uid/<uid>")
@@ -961,6 +976,7 @@ def main(port_api : int, port_tcp : int, pub_pem, pri, ImgCaptcha, user_cursor, 
                 "res/{}/config.json".format(port_api),
                 lambda cfg: cfg.__setitem__("captcha", final_stat),
             )
+            invalidate_config_cache()
         return bool_res()[True]
 
     @api("/auth/change_rate_limits", methods=['POST'])
@@ -998,6 +1014,7 @@ def main(port_api : int, port_tcp : int, pub_pem, pri, ImgCaptcha, user_cursor, 
                 else:
                     cfg["rate_limits"] = new_limits
             update_json("res/{}/config.json".format(port_api), change)
+            invalidate_config_cache()
         limiter.reload(port_api)
         return bool_res()[True]
 


### PR DESCRIPTION
- channel.py: notify_users 批量落库并推送，按 notify_level 偏好决定提醒
- db/notifications.py: add_events 批量插入单事务提交
- db/messages.py: get_room_preference_map 单次查询多人偏好
- db/group.py: 用 json 替代 eval 处理精华列表
- db/tool.py: 每线程独立连接，读不加锁，WAL + synchronous=NORMAL + busy_timeout
- web.py: config 读取加 TTL 缓存，写入后失效
